### PR TITLE
沼津市を東京都配下から静岡県配下に変更

### DIFF
--- a/lib/generators/region_interceptor/templates/csv/city.csv
+++ b/lib/generators/region_interceptor/templates/csv/city.csv
@@ -940,7 +940,7 @@ id,name,code,area_id
 939,加茂郡東白川村,higashishirakawa,49
 940,可児郡御嵩町,mitake,49
 941,岐阜県大野郡白川村,shirakawa,49
-942,沼津市,numazu,32
+942,沼津市,numazu,52
 943,熱海市,atami,52
 944,三島市,mishimashi,52
 945,富士宮市,fujinomiya,52


### PR DESCRIPTION
# 対応内容
city.csvの沼津市が東京都配下になってたので静岡配下に変更

こちらのissuesの対応はほとんどされていましたが沼津だけ対応されていなかったので対応しました
https://github.com/PORT-INC/region_interceptor/issues/6